### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Use a Python image with uv pre-installed
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS uv
+
+# Install the project into /app
+WORKDIR /app
+
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Install the project's dependencies using the lockfile and settings
+COPY pyproject.toml uv.lock /app/
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen --no-install-project --no-dev --no-editable
+
+# Then, add the rest of the project source code and install it
+# Installing separately from its dependencies allows optimal layer caching
+ADD src /app/src
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen --no-dev --no-editable
+
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app
+
+COPY --from=uv /root/.local /root/.local
+COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Define environment variable for Duffel API key
+ENV DUFFEL_API_KEY_LIVE=your_duffel_live_api_key_here
+
+# Start the MCP server
+ENTRYPOINT ["flights-mcp"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Find Flights MCP Server
+[![smithery badge](https://smithery.ai/badge/@ravinahp/travel-mcp)](https://smithery.ai/server/@ravinahp/travel-mcp)
 MCP server for searching and retrieving flight information using Duffel API.
 
 ## How it Works
@@ -70,6 +71,16 @@ This MCP server only uses Duffel's search endpoints and cannot make bookings or 
 - Recommended to review current pricing on their website
 
 ## Installation
+
+### Installing via Smithery
+
+To install Find Flights for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@ravinahp/travel-mcp):
+
+```bash
+npx -y @smithery/cli install @ravinahp/travel-mcp --client claude
+```
+
+### Manual Installation
 Clone the repository:
 ```bash
 git clone https://github.com/ravinahp/flights-mcp

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - duffelApiKeyLive
+    properties:
+      duffelApiKeyLive:
+        type: string
+        description: The live API key for accessing the Duffel flight search service.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'flights-mcp', env: { DUFFEL_API_KEY_LIVE: config.duffelApiKeyLive } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai?utm_campaign=pr) to render configurations for the end-user. It also allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@ravinahp/travel-mcp?utm_campaign=pr&modal=claim), claiming it and clicking "Deploy".
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. Note that the installation only works after the server is deployed.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂