### PR TITLE
add mcp as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,12 @@
 name = "flights-mcp"
 version = "0.1.0"
 description = "Flight search MCP server using Duffel API"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "httpx",
     "python-dotenv",
-    "pydantic"
+    "pydantic",
+    "mcp",
 ]
 license = "MIT"
 


### PR DESCRIPTION
Fixing the missing dependency to the mcp SDK, and bumping the python version requirement