### PR TITLE
Bump Duffl API version to v2

### DIFF
--- a/src/flights/api/client.py
+++ b/src/flights/api/client.py
@@ -8,26 +8,26 @@ from .endpoints import OfferEndpoints
 
 class DuffelClient:
     """Client for interacting with the Duffel API."""
-    
+
     def __init__(self, logger: logging.Logger, timeout: float = 30.0):
         """Initialize the Duffel API client."""
         self.logger = logger
         self.timeout = timeout
         self._token = get_api_token()
         self.base_url = "https://api.duffel.com/air"
-        
+
         # Headers setup
         self.headers = {
             "Accept": "application/json",
             "Accept-Encoding": "gzip",
-            "Duffel-Version": "v1",
+            "Duffel-Version": "v2",
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json"
         }
-        
+
         self.logger.info(f"API key starts with: {self._token[:8] if self._token else None}")
         self.logger.info(f"Using base URL: {self.base_url}")
-        
+
         # Initialize endpoints
         self.offers = OfferEndpoints(self.base_url, self.headers, self.logger)
 
@@ -45,4 +45,4 @@ class DuffelClient:
 
     async def get_offer(self, offer_id: str) -> Dict[str, Any]:
         """Get offer details."""
-        return await self.offers.get_offer(offer_id) 
+        return await self.offers.get_offer(offer_id)


### PR DESCRIPTION
Duffl API v1 returns an HTTP error 400 due to version deprecation. This PR updates the header to use v2. No further changes seem to be required for basic functionality.